### PR TITLE
Allow CORS access to Remote

### DIFF
--- a/src/main/managers/PlayerManager.ts
+++ b/src/main/managers/PlayerManager.ts
@@ -39,6 +39,19 @@ export class PlayerManager {
     this.port = port;
 
     this.fastify = Fastify();
+    // Disable CORS checks so we can access the remote from a browser (e.g. VTT)
+    this.fastify.addHook('preHandler', (req, res, done) => {
+      res.header("Access-Control-Allow-Origin", "*");
+      res.header("Access-Control-Allow-Methods", "*");
+      res.header("Access-Control-Allow-Headers",  "*");
+      
+      const isPreflight = /options/i.test(req.method);
+      if (isPreflight) {
+        return res.send();
+      }
+          
+      done();
+    })
 
     registerRemote(this);
 


### PR DESCRIPTION
I wanted to call the "remote" REST API from my VTT (Foundry).

Unfortunately modern browsers check the CORS headers of the server being called (the Kenku.fm remote in this case) and since Kenku doesn't explicitly allow cross-origin access from other sites (e.g. my VTT host), the browser simply blocks the request.

The patch enables CORS requests from any other site to the remote.
Of course if would be even nicer and more secure to have it configurable...